### PR TITLE
[Entity] Ad Entity, User Entity, Web_Info Entity, Web_Eps Entity_23.06.20

### DIFF
--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/entity/Ad.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/entity/Ad.java
@@ -1,5 +1,26 @@
 package com.example.naverwebtoonclone.advertisement.entity;
 
-public class Ad {
+import com.example.naverwebtoonclone.utils.audit.Auditable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Ad extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column
+    private String contents;
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/user/entity/User.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/user/entity/User.java
@@ -1,5 +1,52 @@
 package com.example.naverwebtoonclone.user.entity;
 
-public class User {
+import com.example.naverwebtoonclone.utils.audit.Auditable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class User extends Auditable{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<String> roles = new ArrayList<>();
+
+    @Enumerated(value = EnumType.STRING)
+    @Column
+    private UserStatus userStatus;
+
+
+    public enum UserStatus {
+        USER_ACTIVE("활동중"),
+        USER_SLEEP("휴면 상태"),
+        USER_QUIT("탈퇴 상태");
+
+        @Getter
+        private String status;
+
+        UserStatus(String status) {
+            this.status = status;
+        }
+    }
 
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/user/entity/User.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/user/entity/User.java
@@ -1,6 +1,8 @@
 package com.example.naverwebtoonclone.user.entity;
 
+import com.example.naverwebtoonclone.advertisement.entity.Ad;
 import com.example.naverwebtoonclone.utils.audit.Auditable;
+import com.example.naverwebtoonclone.web_info.entity.WebInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
@@ -10,6 +12,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -28,8 +33,14 @@ public class User extends Auditable{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @OneToMany(mappedBy = "etpId")
+    private List<Ad> ads = new ArrayList<>();
+
+    @OneToMany(mappedBy = "authorId")
+    private List<WebInfo> webInfos = new ArrayList<>();
+
     @ElementCollection(fetch = FetchType.EAGER)
-    private List<String> roles = new ArrayList<>();
+    private List<String> userRoles = new ArrayList<>();
 
     @Enumerated(value = EnumType.STRING)
     @Column

--- a/server/src/main/java/com/example/naverwebtoonclone/web_details/controller/WebDetController.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_details/controller/WebDetController.java
@@ -1,5 +1,0 @@
-package com.example.naverwebtoonclone.web_details.controller;
-
-public class WebDetController {
-
-}

--- a/server/src/main/java/com/example/naverwebtoonclone/web_details/dto/WebDetDto.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_details/dto/WebDetDto.java
@@ -1,5 +1,0 @@
-package com.example.naverwebtoonclone.web_details.dto;
-
-public class WebDetDto {
-
-}

--- a/server/src/main/java/com/example/naverwebtoonclone/web_details/entity/WebDet.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_details/entity/WebDet.java
@@ -1,5 +1,0 @@
-package com.example.naverwebtoonclone.web_details.entity;
-
-public class WebDet {
-
-}

--- a/server/src/main/java/com/example/naverwebtoonclone/web_details/mapper/WebDetMapper.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_details/mapper/WebDetMapper.java
@@ -1,5 +1,0 @@
-package com.example.naverwebtoonclone.web_details.mapper;
-
-public interface WebDetMapper {
-
-}

--- a/server/src/main/java/com/example/naverwebtoonclone/web_details/repository/WebDetRepository.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_details/repository/WebDetRepository.java
@@ -1,5 +1,0 @@
-package com.example.naverwebtoonclone.web_details.repository;
-
-public interface WebDetRepository {
-
-}

--- a/server/src/main/java/com/example/naverwebtoonclone/web_details/service/WebDetService.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_details/service/WebDetService.java
@@ -1,5 +1,0 @@
-package com.example.naverwebtoonclone.web_details.service;
-
-public class WebDetService {
-
-}

--- a/server/src/main/java/com/example/naverwebtoonclone/web_eps/controller/WebEpsController.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_eps/controller/WebEpsController.java
@@ -1,0 +1,5 @@
+package com.example.naverwebtoonclone.web_eps.controller;
+
+public class WebEpsController {
+
+}

--- a/server/src/main/java/com/example/naverwebtoonclone/web_eps/dto/WebEpsDto.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_eps/dto/WebEpsDto.java
@@ -1,0 +1,5 @@
+package com.example.naverwebtoonclone.web_eps.dto;
+
+public class WebEpsDto {
+
+}

--- a/server/src/main/java/com/example/naverwebtoonclone/web_eps/entity/WebEps.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_eps/entity/WebEps.java
@@ -1,7 +1,7 @@
-package com.example.naverwebtoonclone.advertisement.entity;
+package com.example.naverwebtoonclone.web_eps.entity;
 
-import com.example.naverwebtoonclone.user.entity.User;
-import com.example.naverwebtoonclone.utils.audit.Auditable;
+import com.example.naverwebtoonclone.web_info.entity.WebInfo;
+import com.example.naverwebtoonclone.web_views.entity.WebViews;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,20 +20,30 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Ad extends Auditable {
+public class WebEps {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User etpId;
+    @JoinColumn(name = "web_info_id")
+    private WebInfo webInfoId;
+
+    @OneToOne(mappedBy = "webEpsId")
+    private WebViews webViewsId;
 
     @Column
-    private String contents;
+    private String title;
 
     @Column
-    private String links;
+    private String content;
+
+    @Column
+    private double star;
+
+    @Column
+    private Long starCnt;
+
 
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/web_eps/mapper/WebEpsMapper.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_eps/mapper/WebEpsMapper.java
@@ -1,0 +1,5 @@
+package com.example.naverwebtoonclone.web_eps.mapper;
+
+public interface WebEpsMapper {
+
+}

--- a/server/src/main/java/com/example/naverwebtoonclone/web_eps/repository/WebEpsRepository.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_eps/repository/WebEpsRepository.java
@@ -1,0 +1,5 @@
+package com.example.naverwebtoonclone.web_eps.repository;
+
+public interface WebEpsRepository {
+
+}

--- a/server/src/main/java/com/example/naverwebtoonclone/web_eps/service/WebEpsService.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_eps/service/WebEpsService.java
@@ -1,0 +1,5 @@
+package com.example.naverwebtoonclone.web_eps.service;
+
+public class WebEpsService {
+
+}

--- a/server/src/main/java/com/example/naverwebtoonclone/web_info/entity/WebInfo.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_info/entity/WebInfo.java
@@ -1,5 +1,123 @@
 package com.example.naverwebtoonclone.web_info.entity;
 
-public class WebInfo {
+import com.example.naverwebtoonclone.user.entity.User;
+import com.example.naverwebtoonclone.utils.audit.Auditable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class WebInfo extends Auditable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User authorId;
+
+    @Column
+    private String name;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column
+    private WebStatus webStatus;
+
+    @Column
+    private boolean update;
+
+    @Column
+    private int avgStar;
+
+    @Column
+    private String thumbnail;
+
+    @Column
+    private String details;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column
+    private AgeLimitCode ageLimitCode;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column
+    private CategoryCode categoryCode;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column
+    private Dow dow;
+
+    @Column
+    private int likeCnt;
+
+    @Column
+    private int viewCnt;
+
+
+    public enum WebStatus {
+        Web_ACTIVE("연재"),
+        Web_SLEEP("휴재"),
+        Web_QUIT("완결");
+
+        @Getter
+        private String status;
+
+        WebStatus(String status) {
+            this.status = status;
+        }
+    }
+
+    //TODO code류 정보
+    public enum AgeLimitCode {
+        Web_ACTIVE("연재"),
+        Web_SLEEP("휴재"),
+        Web_QUIT("완결");
+
+        @Getter
+        private String status;
+
+        AgeLimitCode(String status) {
+            this.status = status;
+        }
+    }
+    //TODO code류 정보
+    public enum CategoryCode {
+        Web_ACTIVE("연재"),
+        Web_SLEEP("휴재"),
+        Web_QUIT("완결");
+
+        @Getter
+        private String status;
+
+        CategoryCode(String status) {
+            this.status = status;
+        }
+    }
+
+    public enum Dow {
+        Web_ACTIVE("연재"),
+        Web_SLEEP("휴재"),
+        Web_QUIT("완결");
+
+        @Getter
+        private String status;
+
+        Dow(String status) {
+            this.status = status;
+        }
+    }
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/web_likes/entity/WebLikes.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_likes/entity/WebLikes.java
@@ -1,8 +1,7 @@
-package com.example.naverwebtoonclone.advertisement.entity;
+package com.example.naverwebtoonclone.web_likes.entity;
 
 import com.example.naverwebtoonclone.user.entity.User;
-import com.example.naverwebtoonclone.utils.audit.Auditable;
-import jakarta.persistence.Column;
+import com.example.naverwebtoonclone.web_info.entity.WebInfo;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,7 +18,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Ad extends Auditable {
+public class WebLikes {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,12 +26,9 @@ public class Ad extends Auditable {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
-    private User etpId;
+    private User userId;
 
-    @Column
-    private String contents;
-
-    @Column
-    private String links;
-
+    @ManyToOne
+    @JoinColumn(name = "web_info_id")
+    private WebInfo webInfoId;
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/web_views/entity/WebViews.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_views/entity/WebViews.java
@@ -1,14 +1,15 @@
-package com.example.naverwebtoonclone.advertisement.entity;
+package com.example.naverwebtoonclone.web_views.entity;
 
 import com.example.naverwebtoonclone.user.entity.User;
-import com.example.naverwebtoonclone.utils.audit.Auditable;
-import jakarta.persistence.Column;
+import com.example.naverwebtoonclone.web_eps.entity.WebEps;
+import com.example.naverwebtoonclone.web_info.entity.WebInfo;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,7 +20,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Ad extends Auditable {
+public class WebViews {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,12 +28,13 @@ public class Ad extends Auditable {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
-    private User etpId;
+    private User userId;
 
-    @Column
-    private String contents;
+    @ManyToOne
+    @JoinColumn(name = "web_info_id")
+    private WebInfo webInfoId;
 
-    @Column
-    private String links;
-
+    @OneToOne
+    @JoinColumn(name = "web_eps_id")
+    private WebEps webEpsId;
 }


### PR DESCRIPTION
# 23.06.20
### 엔티티 연관 관계; JPA
- User : Ad = 1 : N
- User : Web_Info = 1 : N
- User : Web_Like = 1 : N
- User : Web_View = 1 : N
- Web_Info : Web_Eps = 1 : N
- Web_Info : Web_Like = 1 : N
- Web_Info : Web_View = 1 : N
- Web_Eps : Web_View = 1 : 1

### User
- 유저(일반)
  - 유저가 여러 개의 관심 웹툰을 지정할 수 있음
  - 유저가 웹툰을 조회한 경우도 DB에 저장
    - 유저가 여러 웹툰을 조회할 수 있음
    - 웹툰을 조회할 땐, 웹툰의 여러 회차 중 하나의 회차만이 가장 최근 조회 데이터가 될 예정
- 유저(작가)
  - 유저가 여러 개의 웹툰을 제작할 수 있음
- 유저(기업)
  - 유저가 여러 광고를 낼 수 있음
- 유저(관리자)

### Web_Info
- 웹툰이 여러 유저에게 관심 지정받을 수 있음.
  - 관심을 받은 개수는 따로 로직을 만들고, 숫자로 따로 속성에 저장
- 웹툰이 여러 유저에게 조회될 수 있음.
  - 관심과 마찬가지로 조회수는 따로 속성에 저장
- 웹툰이 여러 회차를 갖을 수 있음

### Web_Eps
- 해당 회차가 조회됐음을 Web_View에 저장