### PR TITLE
[Ad] Ad Basement; 23.06.22

### DIFF
--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/controller/AdController.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/controller/AdController.java
@@ -1,5 +1,44 @@
 package com.example.naverwebtoonclone.advertisement.controller;
 
+import com.example.naverwebtoonclone.advertisement.mapper.AdMapper;
+import com.example.naverwebtoonclone.advertisement.service.AdService;
+import jakarta.websocket.server.PathParam;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ads")
+@Validated
+@Slf4j
+@RequiredArgsConstructor
 public class AdController {
+
+    private final AdService service;
+    private final AdMapper mapper;
+
+    @PostMapping
+    public ResponseEntity postAd(){return null;}
+
+    @GetMapping
+    public ResponseEntity exposeAd(){return null;}
+    @GetMapping("/{ad-id}")
+    public ResponseEntity selectAdOne(@PathVariable("ad-id") Long adId){return null;}
+    @GetMapping
+    public ResponseEntity selectAdAll(){return null;}
+
+    @PatchMapping("/{ad-id}")
+    public ResponseEntity updateAd(@PathVariable("ad-id") Long adId){return null;}
+
+    @DeleteMapping("/{ad-id}")
+    public ResponseEntity deleteAd(){return null;}
 
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/dto/AdDto.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/dto/AdDto.java
@@ -1,5 +1,41 @@
 package com.example.naverwebtoonclone.advertisement.dto;
 
+import com.example.naverwebtoonclone.user.entity.User;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 public class AdDto {
 
+    @AllArgsConstructor
+    @Getter
+    public static class Post{
+
+        private String contents;
+        private String links;
+
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class Patch{
+
+        private Long id;
+        private User etpId;
+        private String contents;
+        private String links;
+
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class Response{
+
+        private Long id;
+        private String contents;
+        private String links;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+
+    }
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/mapper/AdMapper.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/mapper/AdMapper.java
@@ -1,5 +1,17 @@
 package com.example.naverwebtoonclone.advertisement.mapper;
 
+import com.example.naverwebtoonclone.advertisement.dto.AdDto;
+import com.example.naverwebtoonclone.advertisement.dto.AdDto.Response;
+import com.example.naverwebtoonclone.advertisement.entity.Ad;
+import java.util.List;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
 public interface AdMapper {
+
+    Ad postDtoToEntity (AdDto.Post postRequest);
+    Ad patchDtoToEntity (AdDto.Patch patchRequest);
+    AdDto.Response entityToResponse (Ad ad);
+    List<AdDto.Response> adListToResponseList (List<Ad> adList);
 
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/repository/AdRepository.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/repository/AdRepository.java
@@ -1,5 +1,8 @@
 package com.example.naverwebtoonclone.advertisement.repository;
 
-public interface AdRepository {
+import com.example.naverwebtoonclone.advertisement.entity.Ad;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdRepository extends JpaRepository<Ad, Long> {
 
 }


### PR DESCRIPTION
### Ad Api
|번호|기능명|API명|권한|설명|
|:---:|:---:|:---:|:---:|:---:|
|1|광고 추가|postAd|관리자|광고 엔티티의 모든 속성 필수|
|2|광고 노출|exposeAd|일반, 관리자|1.자동 순차별 조회 2.노출 횟수 조절(optional)|
|3|광고 조회(개별)|selectAdOne|관리자|특정 광고 상세 조회|
|4|광고 조회(전체)|selectAdAll|관리자|모든 광고를 조회, 페이지네이션, 카테고리별 검색(optional), 키워드 검색(optional)|
|5|광고 수정|updateAd|관리자|같은 기업의 광고 내용 혹은 링크를 수정할 때 사용|
|6|광고 삭제|deleteAd|관리자|해당 기업의 광고 삭제|

### Controller
- base annotation 작성
- service di
- mapper di
- API 대응 Handler Methods frame 구성

### Dto
- frame 및 필드 작성

### Entity
- 가독성 개선(주석 구분)
- status default value 부여

### Mapper
- dto <=> entity 간 기본 Mapping 구현

### Repository
- JpaRepository 상속 구현

### Service