### PR TITLE
[Ad] Ad Basement; 23.06.23

### DIFF
--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/controller/AdController.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/controller/AdController.java
@@ -1,5 +1,44 @@
 package com.example.naverwebtoonclone.advertisement.controller;
 
+import com.example.naverwebtoonclone.advertisement.mapper.AdMapper;
+import com.example.naverwebtoonclone.advertisement.service.AdService;
+import jakarta.websocket.server.PathParam;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ads")
+@Validated
+@Slf4j
+@RequiredArgsConstructor
 public class AdController {
+
+    private final AdService service;
+    private final AdMapper mapper;
+
+    @PostMapping
+    public ResponseEntity postAd(){return null;}
+
+    @GetMapping
+    public ResponseEntity exposeAd(){return null;}
+    @GetMapping("/{ad-id}")
+    public ResponseEntity selectAdOne(@PathVariable("ad-id") Long adId){return null;}
+    @GetMapping
+    public ResponseEntity selectAdAll(){return null;}
+
+    @PatchMapping("/{ad-id}")
+    public ResponseEntity updateAd(@PathVariable("ad-id") Long adId){return null;}
+
+    @DeleteMapping("/{ad-id}")
+    public ResponseEntity deleteAd(){return null;}
 
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/controller/AdController.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/controller/AdController.java
@@ -1,10 +1,15 @@
 package com.example.naverwebtoonclone.advertisement.controller;
 
+import com.example.naverwebtoonclone.advertisement.dto.AdDto;
+import com.example.naverwebtoonclone.advertisement.entity.Ad;
 import com.example.naverwebtoonclone.advertisement.mapper.AdMapper;
 import com.example.naverwebtoonclone.advertisement.service.AdService;
-import jakarta.websocket.server.PathParam;
+import com.example.naverwebtoonclone.utils.dtoUtils.MultiResponseDto;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -12,7 +17,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,19 +33,51 @@ public class AdController {
     private final AdMapper mapper;
 
     @PostMapping
-    public ResponseEntity postAd(){return null;}
+    public ResponseEntity postAd(@RequestBody AdDto.Post postRequest){
+        Ad adForService = mapper.postDtoToEntity(postRequest);
+        Ad adForResponse = service.createAd(adForService);
+        AdDto.Response response = mapper.entityToResponse(adForResponse);
 
-    @GetMapping
-    public ResponseEntity exposeAd(){return null;}
+        return new ResponseEntity(response, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/exposure")
+    public ResponseEntity exposeAd(){
+        //TODO 새로 고침할 때 마다 호출, 랜덤으로 호출
+        Ad adForResponse = service.exposeAd();
+        AdDto.Response response = mapper.entityToResponse(adForResponse);
+        return new ResponseEntity(response, HttpStatus.OK);
+    }
     @GetMapping("/{ad-id}")
-    public ResponseEntity selectAdOne(@PathVariable("ad-id") Long adId){return null;}
+    public ResponseEntity selectAdOne(@PathVariable("ad-id") Long adId){
+        Ad adForResponse = service.findOneAd(adId);
+        AdDto.Response response = mapper.entityToResponse(adForResponse);
+
+        return new ResponseEntity(response, HttpStatus.OK);
+    }
     @GetMapping
-    public ResponseEntity selectAdAll(){return null;}
+    public ResponseEntity selectAdAll(@RequestParam int page, @RequestParam int size){
+        Page<Ad> pageAd = service.findAllAd(page-1, size);
+        List<Ad> adListForResponse = pageAd.getContent();
+        List<AdDto.Response> response = mapper.adListToResponseList(adListForResponse);
+
+        return new ResponseEntity(new MultiResponseDto<>(response, pageAd), HttpStatus.OK);
+    }
 
     @PatchMapping("/{ad-id}")
-    public ResponseEntity updateAd(@PathVariable("ad-id") Long adId){return null;}
+    public ResponseEntity updateAd(@PathVariable("ad-id") Long adId, @RequestBody AdDto.Patch patchRequest){
+        Ad adForService = mapper.patchDtoToEntity(patchRequest);
+        Ad adForResponse = service.updateAd(adId, adForService);
+        AdDto.Response response = mapper.entityToResponse(adForResponse);
+
+        return new ResponseEntity(response, HttpStatus.OK);
+    }
 
     @DeleteMapping("/{ad-id}")
-    public ResponseEntity deleteAd(){return null;}
+    public ResponseEntity deleteAd(@PathVariable("ad-id") Long adId){
+        service.deleteOneAd(adId);
+
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
+    }
 
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/dto/AdDto.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/dto/AdDto.java
@@ -1,5 +1,41 @@
 package com.example.naverwebtoonclone.advertisement.dto;
 
+import com.example.naverwebtoonclone.user.entity.User;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 public class AdDto {
 
+    @AllArgsConstructor
+    @Getter
+    public static class Post{
+
+        private String contents;
+        private String links;
+
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class Patch{
+
+        private Long id;
+        private User etpId;
+        private String contents;
+        private String links;
+
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class Response{
+
+        private Long id;
+        private String contents;
+        private String links;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+
+    }
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/dto/AdDto.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/dto/AdDto.java
@@ -11,7 +11,7 @@ public class AdDto {
     @Getter
     public static class Post{
 
-        private String contents;
+        private String content;
         private String links;
 
     }
@@ -22,7 +22,7 @@ public class AdDto {
 
         private Long id;
         private User etpId;
-        private String contents;
+        private String content;
         private String links;
 
     }
@@ -32,7 +32,7 @@ public class AdDto {
     public static class Response{
 
         private Long id;
-        private String contents;
+        private String content;
         private String links;
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;

--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/entity/Ad.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/entity/Ad.java
@@ -30,7 +30,7 @@ public class Ad extends Auditable {
     private User etpId;
 
     @Column
-    private String contents;
+    private String content;
 
     @Column
     private String links;

--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/mapper/AdMapper.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/mapper/AdMapper.java
@@ -1,5 +1,17 @@
 package com.example.naverwebtoonclone.advertisement.mapper;
 
+import com.example.naverwebtoonclone.advertisement.dto.AdDto;
+import com.example.naverwebtoonclone.advertisement.dto.AdDto.Response;
+import com.example.naverwebtoonclone.advertisement.entity.Ad;
+import java.util.List;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
 public interface AdMapper {
+
+    Ad postDtoToEntity (AdDto.Post postRequest);
+    Ad patchDtoToEntity (AdDto.Patch patchRequest);
+    AdDto.Response entityToResponse (Ad ad);
+    List<AdDto.Response> adListToResponseList (List<Ad> adList);
 
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/repository/AdRepository.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/repository/AdRepository.java
@@ -1,5 +1,8 @@
 package com.example.naverwebtoonclone.advertisement.repository;
 
-public interface AdRepository {
+import com.example.naverwebtoonclone.advertisement.entity.Ad;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdRepository extends JpaRepository<Ad, Long> {
 
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/advertisement/service/AdService.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/advertisement/service/AdService.java
@@ -1,5 +1,70 @@
 package com.example.naverwebtoonclone.advertisement.service;
 
-public interface AdService {
+import com.example.naverwebtoonclone.advertisement.entity.Ad;
+import com.example.naverwebtoonclone.advertisement.repository.AdRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class AdService {
+    
+    private final AdRepository repository;
+
+    public Ad createAd(Ad ad) {
+        Ad savedAd = repository.save(ad);
+
+        return savedAd;
+    }
+
+    public Ad exposeAd() {
+//        Ad savedAd = repository
+//        return savedAd;
+        return null;
+    }
+
+    public Ad findOneAd(Long adId) {
+        Ad findAd = findVerifiedAd(adId);
+
+        return findAd;
+    }
+
+    public Page<Ad> findAllAd(int page, int size) {
+        Page<Ad> pageAds = repository.findAll(PageRequest.of(page, size, Sort.by("id").descending()));
+
+        return pageAds;
+    }
+
+    public Ad updateAd(Long adId, Ad ad) {
+        Ad findAd = findVerifiedAd(adId);
+
+        Optional.ofNullable(ad.getContent())
+                .ifPresent(content -> findAd.setContent(content));
+        Optional.ofNullable(ad.getLinks())
+                .ifPresent(link -> ad.setLinks(link));
+
+        Ad savedAd = repository.save(ad);
+
+        return savedAd;
+    }
+
+    public void deleteOneAd(Long adId) {
+        Ad findAd = findVerifiedAd(adId);
+        repository.delete(findAd);
+    }
+
+    private Ad findVerifiedAd(Long adId) {
+        Optional<Ad> optionalAd = repository.findById(adId);
+        Ad findAd = optionalAd.orElseThrow();
+
+        return findAd;
+    }
 }


### PR DESCRIPTION
### Ad Api
|번호|기능명|API명|권한|설명|
|:---:|:---:|:---:|:---:|:---:|
|1|광고 추가|postAd|관리자|광고 엔티티의 모든 속성 필수|
|2|광고 노출|exposeAd|일반, 관리자|1.자동 순차별 조회 2.노출 횟수 조절(optional)|
|3|광고 조회(개별)|selectAdOne|관리자|특정 광고 상세 조회|
|4|광고 조회(전체)|selectAdAll|관리자|모든 광고를 조회, 페이지네이션, 카테고리별 검색(optional), 키워드 검색(optional)|
|5|광고 수정|updateAd|관리자|같은 기업의 광고 내용 혹은 링크를 수정할 때 사용|
|6|광고 삭제|deleteAd|관리자|해당 기업의 광고 삭제|

### Controller
- base annotation 작성
- service di
- mapper di
- API 대응 Handler Methods frame 구성

### Dto
- frame 및 필드 작성

### Entity
- 가독성 개선(주석 구분)
- status default value 부여

### Mapper
- dto <=> entity 간 기본 Mapping 구현

### Repository
- JpaRepository 상속 구현

### Service