### PR TITLE
[WebInfo ] WebInfo Basement; 23.06.23

### DIFF
--- a/server/src/main/java/com/example/naverwebtoonclone/web_info/controller/WebInfoController.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_info/controller/WebInfoController.java
@@ -1,5 +1,69 @@
 package com.example.naverwebtoonclone.web_info.controller;
 
+import com.example.naverwebtoonclone.utils.dtoUtils.MultiResponseDto;
+import com.example.naverwebtoonclone.web_info.dto.WebInfoDto;
+import com.example.naverwebtoonclone.web_info.entity.WebInfo;
+import com.example.naverwebtoonclone.web_info.mapper.WebInfoMapper;
+import com.example.naverwebtoonclone.web_info.service.WebInfoService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/web-infos")
+@Validated
+@Slf4j
+@RequiredArgsConstructor
 public class WebInfoController {
+
+    private final WebInfoService service;
+    private final WebInfoMapper mapper;
+
+    @PostMapping
+    public ResponseEntity postWeb(@RequestBody WebInfoDto.Post postRequest){
+        WebInfo webInfoForService = mapper.postDtoToEntity(postRequest);
+        WebInfo webInfoForResponse = service.createWeb(webInfoForService);
+        WebInfoDto.Response response = mapper.entityToResponse(webInfoForResponse);
+
+
+        return new ResponseEntity(response, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{web-info-id}")
+    public ResponseEntity selectOneWeb(@PathVariable("web-info-id") Long webInfoId){
+        WebInfo webInfoForResponse = service.findOneWeb(webInfoId);
+        WebInfoDto.Response response = mapper.entityToResponse(webInfoForResponse);
+
+        return new ResponseEntity(response, HttpStatus.OK);
+    }
+    @GetMapping
+    public ResponseEntity selectAllWeb(@RequestParam int page, @RequestParam int size){
+        Page<WebInfo> pageAd = service.findAllWeb(page-1, size);
+        List<WebInfo> adListForResponse = pageAd.getContent();
+        List<WebInfoDto.Response> response = mapper.webInfoListToResponseList(adListForResponse);
+
+        return new ResponseEntity(new MultiResponseDto<>(response, pageAd), HttpStatus.OK);
+    }
+
+    @PatchMapping("/{web-info-id}")
+    public ResponseEntity updateWeb(@PathVariable("web-info-id") Long webInfoId, @RequestBody WebInfoDto.Patch patchRequest){
+        WebInfo webInfoForService = mapper.patchDtoToEntity(patchRequest);
+        WebInfo webInfoForResponse = service.updateWeb(webInfoId, webInfoForService);
+        WebInfoDto.Response response = mapper.entityToResponse(webInfoForResponse);
+
+        return new ResponseEntity(response, HttpStatus.OK);
+    }
 
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/web_info/dto/WebInfoDto.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_info/dto/WebInfoDto.java
@@ -1,5 +1,65 @@
 package com.example.naverwebtoonclone.web_info.dto;
 
+import com.example.naverwebtoonclone.user.entity.User;
+import com.example.naverwebtoonclone.web_info.entity.WebInfo.AgeLimitCode;
+import com.example.naverwebtoonclone.web_info.entity.WebInfo.CategoryCode;
+import com.example.naverwebtoonclone.web_info.entity.WebInfo.Dow;
+import com.example.naverwebtoonclone.web_info.entity.WebInfo.WebStatus;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 public class WebInfoDto {
+
+    @AllArgsConstructor
+    @Getter
+    public static class Post{
+
+        private String name;
+        private String thumbnail;
+        private String details;
+        private AgeLimitCode ageLimitCode;
+        private CategoryCode categoryCode;
+        private Dow dow;
+
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class Patch{
+
+        private String name;
+        private String thumbnail;
+        private String details;
+        private int avgStar;
+        private boolean update;
+        private int likeCnt;
+        private int viewCnt;
+        private WebStatus webStatus;
+        private AgeLimitCode ageLimitCode;
+        private CategoryCode categoryCode;
+        private Dow dow;
+
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class Response{
+
+        private String name;
+        private String thumbnail;
+        private String details;
+        private int avgStar;
+        private boolean update;
+        private int likeCnt;
+        private int viewCnt;
+        private WebStatus webStatus;
+        private AgeLimitCode ageLimitCode;
+        private CategoryCode categoryCode;
+        private Dow dow;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+
+    }
 
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/web_info/entity/WebInfo.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_info/entity/WebInfo.java
@@ -22,32 +22,46 @@ import lombok.Setter;
 @AllArgsConstructor
 @Entity
 public class WebInfo extends Auditable {
+
+    //PK
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    //FK
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User authorId;
 
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User adminId;
+
+    //Fields
     @Column
     private String name;
-
-    @Enumerated(value = EnumType.STRING)
-    @Column
-    private WebStatus webStatus;
-
-    @Column
-    private boolean update;
-
-    @Column
-    private int avgStar;
 
     @Column
     private String thumbnail;
 
     @Column
     private String details;
+
+    @Column
+    private String update;
+
+    @Column
+    private double avgStar = 0;
+
+    @Column
+    private int likeCnt = 0;
+
+    @Column
+    private int viewCnt = 0;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column
+    private WebStatus webStatus = WebStatus.Web_ACTIVE;
 
     @Enumerated(value = EnumType.STRING)
     @Column
@@ -60,12 +74,6 @@ public class WebInfo extends Auditable {
     @Enumerated(value = EnumType.STRING)
     @Column
     private Dow dow;
-
-    @Column
-    private int likeCnt;
-
-    @Column
-    private int viewCnt;
 
 
     public enum WebStatus {
@@ -83,41 +91,58 @@ public class WebInfo extends Auditable {
 
     //TODO code류 정보
     public enum AgeLimitCode {
-        Web_ACTIVE("연재"),
-        Web_SLEEP("휴재"),
-        Web_QUIT("완결");
+        ALL_AGE("전체 이용가"),
+        TWELVE("12세 이용가"),
+        FIFTEEN("15세 이용가"),
+        NINETEEN("19세 이용가");
 
         @Getter
-        private String status;
+        private String age;
 
-        AgeLimitCode(String status) {
-            this.status = status;
+        AgeLimitCode(String age) {
+            this.age = age;
         }
     }
     //TODO code류 정보
     public enum CategoryCode {
-        Web_ACTIVE("연재"),
-        Web_SLEEP("휴재"),
-        Web_QUIT("완결");
+        //판타지, 액션, 로맨스, 학원, 드라마, 공포, 코미디
+        MALE_PREFERENCE("남성 선호"),
+        FEMALE_PREFERENCE("여성 선호"),
+        ALL_AGE_PREFERENCE("모든 연령 선호"),
+        TWELVE_PREFERENCE("12세 이상 선호"),
+        FIFTEEN_PREFERENCE("15세 이상 선호"),
+        NINETEEN_PREFERENCE("19세 이상 선호"),
+        FANTASY("판타지"),
+        ACTION("액션"),
+        ROMANCE("로맨스"),
+        SCHOOL_LIFE("학원"),
+        DRAMA("드라마"),
+        HORROR("공포"),
+        COMEDY("코미디");
 
         @Getter
-        private String status;
+        private String category;
 
-        CategoryCode(String status) {
-            this.status = status;
+        CategoryCode(String category) {
+            this.category = category;
         }
     }
 
+    //TODO 요일 카테고리
     public enum Dow {
-        Web_ACTIVE("연재"),
-        Web_SLEEP("휴재"),
-        Web_QUIT("완결");
+        SUNDAY("일요일"),
+        MONDAY("월요일"),
+        TUESDAY("화요일"),
+        WEDNESDAY("수요일"),
+        THURSDAY("목요일"),
+        FRIDAY("금요일"),
+        SATURDAY("토요일");
 
         @Getter
-        private String status;
+        private String dow;
 
-        Dow(String status) {
-            this.status = status;
+        Dow(String dow) {
+            this.dow = dow;
         }
     }
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/web_info/mapper/WebInfoMapper.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_info/mapper/WebInfoMapper.java
@@ -1,5 +1,16 @@
 package com.example.naverwebtoonclone.web_info.mapper;
 
+import com.example.naverwebtoonclone.web_info.dto.WebInfoDto;
+import com.example.naverwebtoonclone.web_info.entity.WebInfo;
+import java.util.List;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
 public interface WebInfoMapper {
+
+    WebInfo postDtoToEntity (WebInfoDto.Post postRequest);
+    WebInfo patchDtoToEntity (WebInfoDto.Patch patchRequest);
+    WebInfoDto.Response entityToResponse (WebInfo webInfo);
+    List<WebInfoDto.Response> webInfoListToResponseList (List<WebInfo> webInfoList);
 
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/web_info/repository/WebInfoRepository.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_info/repository/WebInfoRepository.java
@@ -1,5 +1,8 @@
 package com.example.naverwebtoonclone.web_info.repository;
 
-public interface WebInfoRepository {
+import com.example.naverwebtoonclone.web_info.entity.WebInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WebInfoRepository extends JpaRepository <WebInfo, Long> {
 
 }

--- a/server/src/main/java/com/example/naverwebtoonclone/web_info/service/WebInfoService.java
+++ b/server/src/main/java/com/example/naverwebtoonclone/web_info/service/WebInfoService.java
@@ -1,5 +1,77 @@
 package com.example.naverwebtoonclone.web_info.service;
 
+import com.example.naverwebtoonclone.web_info.entity.WebInfo;
+import com.example.naverwebtoonclone.web_info.repository.WebInfoRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
 public class WebInfoService {
 
+    private final WebInfoRepository repository;
+
+    public WebInfo createWeb(WebInfo webInfo) {
+        WebInfo savedWebInfo = repository.save(webInfo);
+
+        return savedWebInfo;
+    }
+
+    public WebInfo findOneWeb(Long webId) {
+        WebInfo findWebInfo = findVerifiedWebInfo(webId);
+
+        return findWebInfo;
+    }
+
+    public Page<WebInfo> findAllWeb(int page, int size) {
+        Page<WebInfo> pageAds = repository.findAll(PageRequest.of(page, size, Sort.by("id").descending()));
+
+        return pageAds;
+    }
+
+    public WebInfo updateWeb(Long webId, WebInfo webInfo) {
+        WebInfo findWebInfo = findVerifiedWebInfo(webId);
+
+        Optional.ofNullable(webInfo.getName())
+                .ifPresent(name -> findWebInfo.setName(name));
+        Optional.ofNullable(webInfo.getThumbnail())
+                .ifPresent(thumbnail -> webInfo.setThumbnail(thumbnail));
+        Optional.ofNullable(webInfo.getDetails())
+                .ifPresent(details -> webInfo.setDetails(details));
+        Optional.ofNullable(webInfo.getUpdate())
+                .ifPresent(update -> webInfo.setUpdate(update));
+        Optional.ofNullable(webInfo.getAvgStar())
+                .ifPresent(avgStar -> webInfo.setAvgStar(avgStar));
+        Optional.ofNullable(webInfo.getLikeCnt())
+                .ifPresent(likeCnt -> webInfo.setLikeCnt(likeCnt));
+        Optional.ofNullable(webInfo.getViewCnt())
+                .ifPresent(viewCnt -> webInfo.setViewCnt(viewCnt));
+        Optional.ofNullable(webInfo.getWebStatus())
+                .ifPresent(webStatus -> webInfo.setWebStatus(webStatus));
+        Optional.ofNullable(webInfo.getAgeLimitCode())
+                .ifPresent(ageLimitCode -> webInfo.setAgeLimitCode(ageLimitCode));
+        Optional.ofNullable(webInfo.getCategoryCode())
+                .ifPresent(categoryCode -> webInfo.setCategoryCode(categoryCode));
+        Optional.ofNullable(webInfo.getDow())
+                .ifPresent(dow -> webInfo.setDow(dow));
+
+        WebInfo savedWebInfo = repository.save(findWebInfo);
+
+        return savedWebInfo;
+    }
+
+    private WebInfo findVerifiedWebInfo(Long webId) {
+        Optional<WebInfo> optionalWebInfo = repository.findById(webId);
+        WebInfo findWebInfo = optionalWebInfo.orElseThrow();
+
+        return findWebInfo;
+    }
 }


### PR DESCRIPTION
### WebInfo Api
|번호|기능명|API명|권한|설명|
|:---:|:---:|:---:|:---:|:---:|
|1|웹툰 추가|postWeb|관리자|필수 속성들을 작성하여 추가|
|2|웹툰 조회(개별)|selectWebOne|일반, 관리자|특정 웹툰 상세 조회|
|3|웹툰 조회(전체)|selectWebAll|일반, 관리자|모든 광고를 조회, 페이지네이션(무한 스크롤로 변경 예정), 카테고리별 검색(optional), 키워드 검색(optional)|
|4|웹툰 수정|updateWeb|관리자|웹툰 속성 수정할 때 사용, 웹툰 삭제는 존재하지 않고 상태 변경(휴재 및 완결)만 존재|

### Controller
- base annotation 작성
- service di
- mapper di
- API 대응 Handler Methods frame 구성

### Dto
- frame 및 필드 작성

### Entity
- 관리자 ID FK 추가
- 속성 기본값 설정
- 평균 별점 데이터 타입 수정(int => double, 소수점 사용을 위해)
- enum code 완성

### Mapper
- dto <=> entity 간 기본 Mapping 구현

### Repository
- JpaRepository 상속 구현

### Service
- Handler Methods에 대응하는 기본 service logics 구현